### PR TITLE
Fixed wrong urls in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Visualisierung der Startup-Szene in Karlsruhe
 ================================================================================
 
-Visualisierung der Startups in Karlsruhe mit [leaflet.js](https://leafletjs.com). Daten von [StartUpsKA](http://startupska.de) (aus der Startup-Kategorie). Erreichbar unter [pioniergarage.github.io/karlsruhe-startups](https://pioniergarage.github.io/karlsruhe-startups).
+Visualisierung der Startups in Karlsruhe mit [leaflet.js](https://leafletjs.com). Daten von [StartUpsKA](http://startupska.de) (aus der Startup-Kategorie). Erreichbar unter [pioniergarage.github.io/startups-karlsruhe](https://pioniergarage.github.io/startups-karlsruhe).
 
-[![Heatmap der Startups in Karlsruhe](img/startups-in-karlsruhe.jpg)](https://pioniergarage.github.io/karlsruhe-startups)
+[![Heatmap der Startups in Karlsruhe](img/startups-in-karlsruhe.jpg)](https://pioniergarage.github.io/startups-karlsruhe)
 
 Autor: [@lorey](https://github.com/lorey)


### PR DESCRIPTION
Urls in Readme pointed to .../karlsruhe-startups which is not the
correct url
